### PR TITLE
feat(auth): implement automatic JWT token refresh on 401

### DIFF
--- a/pwa-planteau-api/client/src/services/httpClient.ts
+++ b/pwa-planteau-api/client/src/services/httpClient.ts
@@ -2,6 +2,11 @@
  * HTTP Client for API communication
  * Centralized fetch wrapper with error handling and automatic credential inclusion
  * (for httpOnly cookie authentication)
+ *
+ * Features:
+ * - Automatic JWT refresh on 401 errors
+ * - Automatic retry of failed requests after token refresh
+ * - Prevention of multiple simultaneous refresh attempts
  */
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3000/api';
@@ -19,102 +24,103 @@ const commonOptions: RequestInit = {
   credentials: 'include', // Include httpOnly cookies in requests
 };
 
+/**
+ * State for preventing multiple refresh attempts
+ */
+let isRefreshing = false;
+let refreshPromise: Promise<void> | null = null;
+
+/**
+ * Handle token refresh and automatic retry
+ */
+async function handleTokenRefresh(): Promise<void> {
+  // Prevent multiple simultaneous refresh attempts
+  if (isRefreshing) {
+    return refreshPromise || Promise.resolve();
+  }
+
+  isRefreshing = true;
+
+  try {
+    const { authService } = await import('../features/authentication/service/authService');
+    refreshPromise = authService.refreshToken();
+    await refreshPromise;
+  } catch (error) {
+    console.error('[httpClient] Token refresh failed, redirecting to login', error);
+    // Clear auth state and redirect to login
+    const { authService } = await import('../features/authentication/service/authService');
+    authService.clearToken();
+    window.location.href = '/login';
+    throw error;
+  } finally {
+    isRefreshing = false;
+    refreshPromise = null;
+  }
+}
+
+/**
+ * Execute fetch request with automatic refresh on 401
+ */
+async function executeRequest<T>(
+  endpoint: string,
+  method: string,
+  data?: unknown,
+  isRetry = false
+): Promise<T> {
+  try {
+    const response = await fetch(`${API_BASE_URL}${endpoint}`, {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      ...(data !== undefined && { body: JSON.stringify(data) }),
+      ...commonOptions,
+    });
+
+    if (!response.ok) {
+      // Handle 401 - attempt token refresh and retry
+      if (response.status === 401 && !isRetry && endpoint !== '/auth/refresh') {
+        console.warn(`[httpClient] Token expired, attempting refresh...`);
+        try {
+          await handleTokenRefresh();
+          // Retry the original request
+          return executeRequest<T>(endpoint, method, data, true);
+        } catch (refreshError) {
+          // If refresh fails, throw the original 401 error
+          const error: ApiError = new Error(`HTTP Error: ${response.status}`);
+          error.status = response.status;
+          error.response = await response.json().catch(() => null);
+          throw error;
+        }
+      }
+
+      const error: ApiError = new Error(`HTTP Error: ${response.status}`);
+      error.status = response.status;
+      error.response = await response.json().catch(() => null);
+      throw error;
+    }
+
+    return await response.json();
+  } catch (error) {
+    if (error instanceof Error) {
+      throw error;
+    }
+    throw new Error('Network error');
+  }
+}
+
 export const httpClient = {
   async get<T>(endpoint: string): Promise<T> {
-    try {
-      const response = await fetch(`${API_BASE_URL}${endpoint}`, {
-        method: 'GET',
-        headers: { 'Content-Type': 'application/json' },
-        ...commonOptions,
-      });
-
-      if (!response.ok) {
-        const error: ApiError = new Error(`HTTP Error: ${response.status}`);
-        error.status = response.status;
-        error.response = await response.json().catch(() => null);
-        throw error;
-      }
-
-      return await response.json();
-    } catch (error) {
-      if (error instanceof Error) {
-        throw error;
-      }
-      throw new Error('Network error');
-    }
+    return executeRequest<T>(endpoint, 'GET');
   },
 
   async post<T>(endpoint: string, data: unknown): Promise<T> {
-    try {
-      const response = await fetch(`${API_BASE_URL}${endpoint}`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(data),
-        ...commonOptions,
-      });
-
-      if (!response.ok) {
-        const error: ApiError = new Error(`HTTP Error: ${response.status}`);
-        error.status = response.status;
-        error.response = await response.json().catch(() => null);
-        throw error;
-      }
-
-      return await response.json();
-    } catch (error) {
-      if (error instanceof Error) {
-        throw error;
-      }
-      throw new Error('Network error');
-    }
+    return executeRequest<T>(endpoint, 'POST', data);
   },
 
   async put<T>(endpoint: string, data: unknown): Promise<T> {
-    try {
-      const response = await fetch(`${API_BASE_URL}${endpoint}`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(data),
-        ...commonOptions,
-      });
-
-      if (!response.ok) {
-        const error: ApiError = new Error(`HTTP Error: ${response.status}`);
-        error.status = response.status;
-        error.response = await response.json().catch(() => null);
-        throw error;
-      }
-
-      return await response.json();
-    } catch (error) {
-      if (error instanceof Error) {
-        throw error;
-      }
-      throw new Error('Network error');
-    }
+    return executeRequest<T>(endpoint, 'PUT', data);
   },
 
   async delete<T>(endpoint: string): Promise<T> {
-    try {
-      const response = await fetch(`${API_BASE_URL}${endpoint}`, {
-        method: 'DELETE',
-        headers: { 'Content-Type': 'application/json' },
-        ...commonOptions,
-      });
-
-      if (!response.ok) {
-        const error: ApiError = new Error(`HTTP Error: ${response.status}`);
-        error.status = response.status;
-        error.response = await response.json().catch(() => null);
-        throw error;
-      }
-
-      return await response.json();
-    } catch (error) {
-      if (error instanceof Error) {
-        throw error;
-      }
-      throw new Error('Network error');
-    }
+    return executeRequest<T>(endpoint, 'DELETE');
   },
 };


### PR DESCRIPTION
## 🎯 Objectif
Implémenter le rafraîchissement automatique du JWT access token côté client 

## 🔄 Changements
- Ajout d'un intercepteur 401 dans `httpClient.ts` pour détecter les erreurs liées à la réexpiration du token
- Implémentation de la logique de rafraîchissement automatique du token via `/auth/refresh`
- Retry automatique des requêtes échouées après un refresh réussi

## ✅ Tests
- [x] Tests unitaires passent
- [x] Tests d'intégration passent
- [x] Testé manuellement - Vérification que le token expire et se rafraîchit automatiquement

## 📝 Notes de Review
- Vérifier que le 401 est bien intercepté et gère le refresh automatiquement
- Vérifier que les requêtes sont rejouées correctement après refresh


## 🔗 Issue Liée
#67 